### PR TITLE
remove overlay_utils.hpp from headers_to_moc

### DIFF
--- a/rviz_2d_overlay_plugins/CMakeLists.txt
+++ b/rviz_2d_overlay_plugins/CMakeLists.txt
@@ -13,7 +13,6 @@ find_package(std_msgs REQUIRED)
 
 set(headers_to_moc
         include/overlay_text_display.hpp
-        include/overlay_utils.hpp
         include/pie_chart_display.h
         )
 


### PR DESCRIPTION
the header doesnt contain any Q_OBJECT class, so this fixes the `Note: No relevant classes found. No output generated.` note from the MOC

fixes #15 