### PR TITLE
Fix Qt Widgets linkage for display plugins

### DIFF
--- a/rviz_2d_overlay_plugins/CMakeLists.txt
+++ b/rviz_2d_overlay_plugins/CMakeLists.txt
@@ -12,6 +12,9 @@ if (NOT Qt6_FOUND)
 	if (NOT Qt5_FOUND)
 		message( FATAL_ERROR "Neither QT6 nor QT5 was found!" )
 	endif()
+    set(qt_widgets_target Qt5::Widgets)
+else()
+    set(qt_widgets_target Qt6::Widgets)
 endif()
 
 find_package(rviz_common REQUIRED)
@@ -58,6 +61,7 @@ target_link_libraries(
         rviz_ogre_vendor::OgreOverlay
         rviz_common::rviz_common
         rviz_rendering::rviz_rendering
+        ${qt_widgets_target}
         ${std_msgs_TARGETS}
         ${rviz_2d_overlay_msgs_TARGETS}
 )


### PR DESCRIPTION
Issue:
On ROS 2 Jazzy, the package builds, but RViz fails to load `rviz_2d_overlay_plugins/TextOverlay` because the plugin library is missing the Qt symbols for `OverlayTextDisplay` and `PieChartDisplay`.

Fix:
Linked the detected Qt Widgets target into `rviz_2d_overlay_plugins`. The existing Qt5/Qt6 detection and `AUTOMOC` setup stay the same.

Verification:
- build `rviz_2d_overlay_plugins` with a clean cache
- check the built library with `ldd -r`
- confirm RViz loads the plugin without the undefined-symbol error